### PR TITLE
Add screen enhancement

### DIFF
--- a/drizzle/0012_sloppy_medusa.sql
+++ b/drizzle/0012_sloppy_medusa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `TransactionLists` ADD `isRecurringTransaction` integer DEFAULT false;

--- a/drizzle/0013_cute_imperial_guard.sql
+++ b/drizzle/0013_cute_imperial_guard.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_TransactionLists` (
+	`description` text,
+	`amount` integer NOT NULL,
+	`createdDate` text DEFAULT (CURRENT_DATE),
+	`modifiedDate` text,
+	`id` text PRIMARY KEY NOT NULL,
+	`addedBy` text,
+	`categoryType` text,
+	`transactionType` text,
+	`isDeleted` integer DEFAULT false,
+	`deletedDate` text,
+	`isRecurringTransaction` text DEFAULT '',
+	FOREIGN KEY (`addedBy`) REFERENCES `UserLists`(`userId`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`categoryType`) REFERENCES `Categories`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`transactionType`) REFERENCES `TransactionType`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_TransactionLists`("description", "amount", "createdDate", "modifiedDate", "id", "addedBy", "categoryType", "transactionType", "isDeleted", "deletedDate", "isRecurringTransaction") SELECT "description", "amount", "createdDate", "modifiedDate", "id", "addedBy", "categoryType", "transactionType", "isDeleted", "deletedDate", "isRecurringTransaction" FROM `TransactionLists`;--> statement-breakpoint
+DROP TABLE `TransactionLists`;--> statement-breakpoint
+ALTER TABLE `__new_TransactionLists` RENAME TO `TransactionLists`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,334 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3617bf8a-9eac-4d45-9182-0815237c8a09",
+  "prevId": "530285ed-04b1-4a8e-84a9-8a4b087f654d",
+  "tables": {
+    "BudgetedData": {
+      "name": "BudgetedData",
+      "columns": {
+        "categoryType": {
+          "name": "categoryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "BudgetedData_categoryType_Categories_id_fk": {
+          "name": "BudgetedData_categoryType_Categories_id_fk",
+          "tableFrom": "BudgetedData",
+          "tableTo": "Categories",
+          "columnsFrom": [
+            "categoryType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "BudgetedData_userId_UserLists_userId_fk": {
+          "name": "BudgetedData_userId_UserLists_userId_fk",
+          "tableFrom": "BudgetedData",
+          "tableTo": "UserLists",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "userId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "BudgetedData_userId_categoryType_month_pk": {
+          "columns": [
+            "userId",
+            "categoryType",
+            "month"
+          ],
+          "name": "BudgetedData_userId_categoryType_month_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Categories": {
+      "name": "Categories",
+      "columns": {
+        "categoryName": {
+          "name": "categoryName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transactionType": {
+          "name": "transactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Categories_categoryName_unique": {
+          "name": "Categories_categoryName_unique",
+          "columns": [
+            "categoryName"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Categories_transactionType_TransactionType_id_fk": {
+          "name": "Categories_transactionType_TransactionType_id_fk",
+          "tableFrom": "Categories",
+          "tableTo": "TransactionType",
+          "columnsFrom": [
+            "transactionType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "TransactionLists": {
+      "name": "TransactionLists",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdDate": {
+          "name": "createdDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_DATE)"
+        },
+        "modifiedDate": {
+          "name": "modifiedDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "categoryType": {
+          "name": "categoryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transactionType": {
+          "name": "transactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deletedDate": {
+          "name": "deletedDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRecurringTransaction": {
+          "name": "isRecurringTransaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "TransactionLists_addedBy_UserLists_userId_fk": {
+          "name": "TransactionLists_addedBy_UserLists_userId_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "UserLists",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "userId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TransactionLists_categoryType_Categories_id_fk": {
+          "name": "TransactionLists_categoryType_Categories_id_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "Categories",
+          "columnsFrom": [
+            "categoryType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TransactionLists_transactionType_TransactionType_id_fk": {
+          "name": "TransactionLists_transactionType_TransactionType_id_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "TransactionType",
+          "columnsFrom": [
+            "transactionType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "TransactionType": {
+      "name": "TransactionType",
+      "columns": {
+        "transactionName": {
+          "name": "transactionName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TransactionType_transactionName_unique": {
+          "name": "TransactionType_transactionName_unique",
+          "columns": [
+            "transactionName"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "UserLists": {
+      "name": "UserLists",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isUserOnboarded": {
+          "name": "isUserOnboarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,334 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a8645838-dd9e-4db1-a9d2-486a0dbeaeef",
+  "prevId": "3617bf8a-9eac-4d45-9182-0815237c8a09",
+  "tables": {
+    "BudgetedData": {
+      "name": "BudgetedData",
+      "columns": {
+        "categoryType": {
+          "name": "categoryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "BudgetedData_categoryType_Categories_id_fk": {
+          "name": "BudgetedData_categoryType_Categories_id_fk",
+          "tableFrom": "BudgetedData",
+          "tableTo": "Categories",
+          "columnsFrom": [
+            "categoryType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "BudgetedData_userId_UserLists_userId_fk": {
+          "name": "BudgetedData_userId_UserLists_userId_fk",
+          "tableFrom": "BudgetedData",
+          "tableTo": "UserLists",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "userId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "BudgetedData_userId_categoryType_month_pk": {
+          "columns": [
+            "userId",
+            "categoryType",
+            "month"
+          ],
+          "name": "BudgetedData_userId_categoryType_month_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Categories": {
+      "name": "Categories",
+      "columns": {
+        "categoryName": {
+          "name": "categoryName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transactionType": {
+          "name": "transactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Categories_categoryName_unique": {
+          "name": "Categories_categoryName_unique",
+          "columns": [
+            "categoryName"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Categories_transactionType_TransactionType_id_fk": {
+          "name": "Categories_transactionType_TransactionType_id_fk",
+          "tableFrom": "Categories",
+          "tableTo": "TransactionType",
+          "columnsFrom": [
+            "transactionType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "TransactionLists": {
+      "name": "TransactionLists",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdDate": {
+          "name": "createdDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_DATE)"
+        },
+        "modifiedDate": {
+          "name": "modifiedDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "categoryType": {
+          "name": "categoryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transactionType": {
+          "name": "transactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deletedDate": {
+          "name": "deletedDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRecurringTransaction": {
+          "name": "isRecurringTransaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "TransactionLists_addedBy_UserLists_userId_fk": {
+          "name": "TransactionLists_addedBy_UserLists_userId_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "UserLists",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "userId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TransactionLists_categoryType_Categories_id_fk": {
+          "name": "TransactionLists_categoryType_Categories_id_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "Categories",
+          "columnsFrom": [
+            "categoryType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "TransactionLists_transactionType_TransactionType_id_fk": {
+          "name": "TransactionLists_transactionType_TransactionType_id_fk",
+          "tableFrom": "TransactionLists",
+          "tableTo": "TransactionType",
+          "columnsFrom": [
+            "transactionType"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "TransactionType": {
+      "name": "TransactionType",
+      "columns": {
+        "transactionName": {
+          "name": "transactionName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TransactionType_transactionName_unique": {
+          "name": "TransactionType_transactionName_unique",
+          "columns": [
+            "transactionName"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "UserLists": {
+      "name": "UserLists",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isUserOnboarded": {
+          "name": "isUserOnboarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,20 @@
       "when": 1739670883334,
       "tag": "0011_military_sersi",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1746315875754,
+      "tag": "0012_sloppy_medusa",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1746482423289,
+      "tag": "0013_cute_imperial_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -13,6 +13,8 @@ import m0008 from './0008_broken_odin.sql';
 import m0009 from './0009_confused_sharon_carter.sql';
 import m0010 from './0010_white_veda.sql';
 import m0011 from './0011_military_sersi.sql';
+import m0012 from './0012_sloppy_medusa.sql';
+import m0013 from './0013_cute_imperial_guard.sql';
 
   export default {
     journal,
@@ -28,7 +30,9 @@ m0007,
 m0008,
 m0009,
 m0010,
-m0011
+m0011,
+m0012,
+m0013
     }
   }
   

--- a/schema.ts
+++ b/schema.ts
@@ -29,6 +29,7 @@ export const TransactionLists = sqliteTable('TransactionLists',{
   transactionType: text('transactionType').references(() => TransactionTypes.id),
   isDeleted: integer('isDeleted',{mode: 'boolean'}).default(false),
   deletedDate: text('deletedDate'),
+  isRecurringTransaction: text('isRecurringTransaction').default(''),
 });
 
 export const BudgetedData = sqliteTable('BudgetedData', {

--- a/src/dbOperations/transactionList.ts
+++ b/src/dbOperations/transactionList.ts
@@ -11,6 +11,7 @@ export interface InsertTransactionProps {
   description: typeof TransactionLists.description;
   addedBy: typeof TransactionLists.addedBy;
   id: typeof TransactionLists.id;
+  isRecurringTransaction: typeof TransactionLists.isRecurringTransaction;
 }
 /*
 const transactionList = {
@@ -54,6 +55,7 @@ export const getTransactionForUser = async ({userId}: { userId: string }) => {
         transactionTypeName: TransactionTypes.transactionName,
         description: TransactionLists.description,
         transactionType: TransactionLists.transactionType,
+        isRecurringTransaction: TransactionLists.isRecurringTransaction,
       })
       .from(TransactionLists)
       .where(
@@ -75,7 +77,7 @@ export const getTransactionForUser = async ({userId}: { userId: string }) => {
 };
 
 export const insertTransactionForUser = async (
-  {transactionType, categoryType, createdDate, amount, addedBy, description, dispatch}: InsertTransactionProps) => {
+  {transactionType, categoryType, createdDate, amount, addedBy, description,isRecurringTransaction, dispatch}: InsertTransactionProps) => {
   try {
     const id = (Math.floor(Math.random() * 9999).toString() as unknown as typeof TransactionLists.id);
     const dataToInsert: InsertTransactionProps = {
@@ -86,6 +88,7 @@ export const insertTransactionForUser = async (
       categoryType,
       description,
       addedBy,
+      isRecurringTransaction,
     };
     await db.insert(TransactionLists).values(dataToInsert);
     await getTransactionMonthIndexed({userId: addedBy, dispatch});

--- a/src/dbOperations/transactionList.ts
+++ b/src/dbOperations/transactionList.ts
@@ -12,17 +12,29 @@ export interface InsertTransactionProps {
   addedBy: typeof TransactionLists.addedBy;
   id: typeof TransactionLists.id;
 }
-
+/*
+const transactionList = {
+2025: {
+0: [],
+1: []
+}
+};
+* */
 export const getTransactionMonthIndexed = async ({userId, dispatch}) => {
   const transactionList = await getTransactionForUser({userId});
   const transactionMonthBasis = transactionList.reduce((acc, elm) => {
     const createdDate = new Date(elm.createdDate);
-    const modified = createdDate.setTime(createdDate.getTime() + 955 * 60 *1000)
+    createdDate.setTime(createdDate.getTime() + 955 * 60 *1000)
     const month = createdDate.getMonth();
-    if (month in acc) {
-      acc[month] = [...acc[month], elm]
+    const year = createdDate.getFullYear();
+    if (year in acc) {
+      if(month in acc[year]) {
+        acc[year][month] = [...acc[year][month], elm];
+      }else {
+        acc[year][month] = [elm]
+      }
     } else {
-      acc[month] = [elm];
+      acc[year] = {[month]: [elm]};
     }
     return acc;
   }, {});
@@ -78,6 +90,7 @@ export const insertTransactionForUser = async (
     await db.insert(TransactionLists).values(dataToInsert);
     await getTransactionMonthIndexed({userId: addedBy, dispatch});
   } catch (e) {
-    console.log(JSON.stringify(e), 'error while inserting record')
+    console.log(JSON.stringify(e), 'error while inserting record');
+    throw e;
   }
 }

--- a/src/navigation/stacks/SignedInStack.tsx
+++ b/src/navigation/stacks/SignedInStack.tsx
@@ -17,6 +17,7 @@ import {ImpactFeedbackStyle} from "expo-haptics";
 import {Settings} from "../../screens/signedIn/Settings";
 import {XStack} from "tamagui";
 import React from "react";
+import {RecurringTransaction} from "../../screens/signedIn/RecurringTransaction";
 
 
 const SignedInStack = createBottomTabNavigator();
@@ -44,7 +45,9 @@ const AccountStackScreens = () => {
       <AccountStack.Screen name="appSettings" component={Settings} options={{
         headerTitle: 'Display and Haptics'
       }}/>
-
+      <AccountStack.Screen name="recurringTransactions" component={RecurringTransaction} options={{
+        headerTitle: 'Recurring Transactions'
+      }}/>
     </AccountStack.Navigator>
   );
 }

--- a/src/screens/signedIn/Account.tsx
+++ b/src/screens/signedIn/Account.tsx
@@ -23,13 +23,20 @@ export const Account = () => {
   }
   const onAppSettingPress = () => navigate('appSettings');
 
+  const onRecurringTransactionPress = () => navigate('recurringTransactions');
+
   useEffect(() => {
     console.log(params, 'are params coming here')
     if(params) {
-      if(params.name!='') {
+      if(params.name && params.name!='') {
         navigate('addCategory', {
           name: params.name, id: params.id
-        })
+        });
+        return;
+      }
+      if(params.screen == 'recurringTransaction') {
+        navigate('recurringTransactions');
+        return;
       }
     }
   }, [params]);
@@ -48,6 +55,11 @@ export const Account = () => {
       title: 'Categories',
       footerText: 'View, create or edit categories',
       onPress: handlePress,
+    },
+    {
+      title: 'Recurring Transactions',
+      footerText: 'View, create or edit recurring transactions',
+      onPress: onRecurringTransactionPress,
     },
     {
       title: 'App Settings',
@@ -89,11 +101,7 @@ export const Account = () => {
               elevate
               borderRadius="$8"
               marginVertical="$2"
-              animation="bouncy"
-              scale={0.5}
-              hoverStyle={{scale: 0.925}}
               onPress={item.onPress}
-              pressStyle={{scale: 0.875}}
             >
               <XStack marginVertical="$4" paddingHorizontal="$4" justifyContent="space-between">
                 <H4 size="$6" fontWeight="bold">

--- a/src/screens/signedIn/Add.tsx
+++ b/src/screens/signedIn/Add.tsx
@@ -1,5 +1,5 @@
 import {
-  Button,
+  Button, H5,
   Input,
   Paragraph,
   ScrollView,
@@ -18,6 +18,8 @@ import {DropDown} from "../../components/DropDown";
 import {useDispatch, useSelector} from "react-redux";
 import {RootState} from "../../store";
 import {insertTransactionForUser} from "../../dbOperations/transactionList";
+import {frequencyList} from "../../utils/frequency";
+import {filterDataForDashboard} from "../../utils/filterDataForDashboard";
 
 export const Add = () => {
   const showSuccessToast = () => {
@@ -50,8 +52,8 @@ export const Add = () => {
     const date = today.getDate();
     const year = today.getFullYear();
 
-    const formattedMonth = month <=9 ? `0${month}`: month;
-    const formattedDate = date <=9 ? `0${date}`: date;
+    const formattedMonth = month <= 9 ? `0${month}` : month;
+    const formattedDate = date <= 9 ? `0${date}` : date;
 
     return `${year}-${formattedMonth}-${formattedDate}`;
   }
@@ -63,6 +65,7 @@ export const Add = () => {
   const [description, setDescription] = useState('');
   const [transactionDate, setTransactionDate] = useState(getDefaultDate);
   const [subCategory, setSubCategory] = useState('');
+  const [frequency, setFrequency] = useState(() => frequencyList[0]);
 
   const categories = useSelector((state: RootState) => state.categories);
   const transactionTypes = useSelector((state: RootState) => state.transactionType);
@@ -79,7 +82,6 @@ export const Add = () => {
   const handleAddTransaction = async () => {
     try {
       const transactionToAdd = {
-
         transactionType: categoryType.id,
         amount: Number(amount),
         createdDate: transactionDate,
@@ -87,16 +89,64 @@ export const Add = () => {
         description,
         addedBy: ab?.username,
       };
-      await insertTransactionForUser({
-        ...transactionToAdd,
-dispatch
-      });
-      if (amount == '' || categoryType == '') {
-        showWarningToast();
-      } else {
-        showSuccessToast();
+      if (frequency.id == 'neverRepeat') {
+        await insertTransactionForUser({
+          ...transactionToAdd,
+          dispatch
+        });
+        if (amount == '' || categoryType == '') {
+          showWarningToast();
+        } else {
+          showSuccessToast();
+        }
+        navigate('History');
+      } else if (frequency.id == 'monthly') {
+        const date = new Date(transactionDate);
+        date.setTime(date.getTime() + 955 * 60 * 1000);
+        const currentMonth = date.getMonth();
+        const currentDate = date.getDate();
+        const currentYear = date.getFullYear();
+
+        const formattedDate = currentDate <= 9 ? `0${currentDate}` : currentDate;
+
+        const remainingMonthData = filterDataForDashboard
+          .slice(currentMonth)
+          .map((data) => {
+            const formattedMonth = data.id <= 9 ? `0${data.id + 1}` : data.id + 1;
+            return ({
+              ...transactionToAdd,
+              createdDate: `${currentYear}-${formattedMonth}-${formattedDate}`
+            })
+          });
+        console.log(remainingMonthData, 'data')
+        let showWarning = false;
+        for (const monthData of remainingMonthData) {
+          await insertTransactionForUser({
+            ...monthData,
+            dispatch
+          });
+          if(!showWarning) {
+            if(monthData.amount == '' || categoryType == '') {
+              showWarning =  true;
+            }
+          }
+
+        }
+        if(showWarning) {
+          showWarningToast();
+        } else {
+          showSuccessToast();
+        }
+        navigate('History');
       }
-      navigate('History');
+
+      /*
+      monthly -> get current month and subtract it from total month and loop
+      quarterly -> 4 - current quarter and loop
+
+      * */
+
+
     } catch (e) {
       showErrorToast();
       console.log(e, 'caught error here')
@@ -106,7 +156,7 @@ dispatch
       setDescription('');
       setSubCategory('');
       setTransactionDate(getDefaultDate);
-
+      setFrequency(frequencyList[0]);
     }
 
   }
@@ -135,13 +185,6 @@ dispatch
           onChangeText={setDescription}
           ref={descriptionRef}
         />
-        {/*<DropDown*/}
-        {/*  items={["Doesn't Repeat",'Weekly', 'Bi-Weekly', 'Monthly', 'Semi-Annually', 'Annually']}*/}
-        {/*  placeholder="Transaction Frequency"*/}
-        {/*  // val={}*/}
-        {/*  setVal={console.log}*/}
-        {/*  defaultValue="Doesn't Repeat"*/}
-        {/*/>*/}
         <DropDown
           items={transactionTypes}
           placeholder="Transaction Type"
@@ -158,6 +201,14 @@ dispatch
           keyName='categoryName'
           emptyItemOnPress={handleNavigation}
         />}
+        <DropDown
+          items={frequencyList}
+          placeholder="Transaction Frequency for future transactions"
+          val={frequency}
+          keyName='name'
+          setVal={setFrequency}
+          defaultValue="Never Repeat"
+        />
         <Button
           icon={() => <CalendarIcon stroke="purple"/>}
           size="$6"

--- a/src/screens/signedIn/Add.tsx
+++ b/src/screens/signedIn/Add.tsx
@@ -92,6 +92,7 @@ export const Add = () => {
       if (frequency.id == 'neverRepeat') {
         await insertTransactionForUser({
           ...transactionToAdd,
+          isRecurringTransaction: '',
           dispatch
         });
         if (amount == '' || categoryType == '') {
@@ -112,9 +113,10 @@ export const Add = () => {
         const remainingMonthData = filterDataForDashboard
           .slice(currentMonth)
           .map((data) => {
-            const formattedMonth = data.id <= 9 ? `0${data.id + 1}` : data.id + 1;
+            const formattedMonth = data.id < 9 ? `0${data.id + 1}` : data.id + 1;
             return ({
               ...transactionToAdd,
+              isRecurringTransaction: frequency.id,
               createdDate: `${currentYear}-${formattedMonth}-${formattedDate}`
             })
           });

--- a/src/screens/signedIn/Details.tsx
+++ b/src/screens/signedIn/Details.tsx
@@ -19,7 +19,12 @@ export const Details = () => {
   const [categoryType, setCategoryType] = useState('');
   const [formattedDate, setFormattedDate] = useState();
   const categories = useSelector((state: RootState) => state.categories);
-  const transactionType = useSelector((state: RootState) => state.transactionType)
+  const transactionType = useSelector((state: RootState) => state.transactionType);
+  const transactionList = useSelector((state: RootState) => state.transactionList);
+  const transactionData = Object
+    .values(transactionList)
+    .flatMap(transaction => transaction)
+    .find(data => data.id == params?.entryId)
 
   const showSuccessToastForUpdate = () => {
     DeviceEventEmitter.emit("DISPLAY_TOAST", {

--- a/src/screens/signedIn/History.tsx
+++ b/src/screens/signedIn/History.tsx
@@ -1,5 +1,5 @@
 import {SectionList} from "react-native";
-import {useNavigation, useTheme,} from "@react-navigation/native";
+import {useNavigation, useRoute, useTheme,} from "@react-navigation/native";
 import {Button, Card, H2, H3, H4, H5, Paragraph, ScrollView, Sheet, XStack, YStack,} from "tamagui";
 import * as Haptics from 'expo-haptics';
 import {ImpactFeedbackStyle} from 'expo-haptics';
@@ -75,10 +75,13 @@ const defaultCategory = {
 
 export const History = () => {
   const snapPoints = [70, 70, 70];
+  const currentDate = new Date();
+  const currentYear = currentDate.getUTCFullYear();
   const [showCalendar, setShowCalendar] = useState(false);
   const [activeFilter, setActiveFilter] = useState(() => defaultCategory);
   const allCategories = useSelector((state: RootState) => state.categories);
-  const transactionListByMonth = useSelector((state: RootState) => state.transactionList);
+  const transactionListByYear = useSelector((state: RootState) => state.transactionList);
+  const transactionListByMonth = transactionListByYear[currentYear] ?? {};
   const transactionType = useSelector((state: RootState) => state.transactionType)
   const filterForTransactionType = transactionType.map(type => ({
     ...type,

--- a/src/screens/signedIn/History.tsx
+++ b/src/screens/signedIn/History.tsx
@@ -5,7 +5,7 @@ import * as Haptics from 'expo-haptics';
 import {ImpactFeedbackStyle} from 'expo-haptics';
 import React, {useEffect, useState} from "react";
 
-import {Filter} from "../../icons";
+import {ChevronRight, Filter} from "../../icons";
 import {filterDataForDashboard} from "../../utils/filterDataForDashboard";
 import {useSelector} from "react-redux";
 import {RootState} from "../../store";
@@ -81,6 +81,7 @@ export const History = () => {
   const [activeFilter, setActiveFilter] = useState(() => defaultCategory);
   const allCategories = useSelector((state: RootState) => state.categories);
   const transactionListByYear = useSelector((state: RootState) => state.transactionList);
+  const {colors} = useTheme();
   const transactionListByMonth = transactionListByYear[currentYear] ?? {};
   const transactionType = useSelector((state: RootState) => state.transactionType)
   const filterForTransactionType = transactionType.map(type => ({
@@ -186,9 +187,25 @@ export const History = () => {
             </Button>
           ))}
         </ScrollView>
+
       </XStack>
-
-
+      <YStack marginVertical="$2" marginHorizontal="$2">
+      <Card onPress={() => navigation.navigate('Account', {
+        screen: 'accountEntry',
+        params: {
+          screen: 'recurringTransaction'
+        }
+      })}>
+        <Card.Header>
+          <XStack justifyContent="space-between" alignItems="center">
+          <H5>
+            See recurring transactions
+          </H5>
+          <ChevronRight color={colors.text}/>
+          </XStack>
+        </Card.Header>
+      </Card>
+      </YStack>
       {/* <FlatList*/}
       {/*  data={flatListData}*/}
       {/*  renderItem={({item}) => <RenderItem*/}

--- a/src/screens/signedIn/Insight.tsx
+++ b/src/screens/signedIn/Insight.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {Check, Cross, Warning} from "../../icons";
 import {BannerContainer} from "../../components/Banner/Container";
 import {
@@ -20,13 +20,16 @@ import {filterDataForDashboard} from "../../utils/filterDataForDashboard";
 import {useSelector} from "react-redux";
 import {RootState} from "../../store";
 import {BarChart} from "react-native-gifted-charts";
-import {useTheme} from "@react-navigation/native";
+import {useFocusEffect, useNavigation, useTheme} from "@react-navigation/native";
 import {StyleSheet} from "react-native";
 
 export const Insight = () => {
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
   const budgetedExpense = useSelector((state: RootState) => state.budgetedExpense);
   const expectedIncome = useSelector((state: RootState) => state.expectedIncome);
-  const actualTransactions = useSelector((state: RootState) => state.transactionList);
+  const transactionLists = useSelector((state: RootState) => state.transactionList);
+  const actualTransactions = transactionLists[currentYear] ?? {};
   const categories = useSelector((state: RootState) => state.categories);
   const categoriesForExpense = categories.filter(elm => elm.transactionName == 'Expense')
   const [coordinates, setCoordinates] = useState([]);
@@ -50,6 +53,7 @@ export const Insight = () => {
     const actualData = {
       value: (data?.id in actualTransactions) ? actualTransactions[data.id].reduce((acc, elm) => elm.transactionTypeName == 'Expense' ? acc + Number(elm.amount) : acc, 0) : 0,
       frontColor: '#3251c7',
+
       data
     };
     return [
@@ -60,6 +64,10 @@ export const Insight = () => {
 
   const {width} = useWindowDimensions();
   const {colors} = useTheme();
+
+  useFocusEffect(useCallback(() => {
+    budgetedVsActualScrollRef?.current?.scrollTo({x: coordinatesForExpense[filterDataForDashboard[3].id]})
+  },[scrollRef, budgetedVsActualScrollRef]))
 
   return (
     <ScrollView
@@ -92,6 +100,7 @@ export const Insight = () => {
       >
         <BarChart
           noOfSections={4}
+          isAnimated
           stackData={closerStackData}
           frontColor={colors.text}
           yAxisTextStyle={{
@@ -188,6 +197,7 @@ export const Insight = () => {
         <BarChart
           data={closerBarData}
           rotateLabel
+          isAnimated
           labelWidth={40}
           barBorderRadius={8}
           noOfSections={4}

--- a/src/screens/signedIn/RecurringTransaction.tsx
+++ b/src/screens/signedIn/RecurringTransaction.tsx
@@ -1,0 +1,102 @@
+import {H5, H2, Card, YStack, H3, Paragraph, XStack} from "tamagui";
+import {useNavigation, useTheme} from "@react-navigation/native";
+import {ChevronRight} from "../../icons";
+import {useSelector} from "react-redux";
+import {RootState} from "../../store";
+import {SectionList} from "react-native";
+
+export const RecurringTransaction = () => {
+  const {colors} = useTheme();
+  const currentDate = new Date();
+  const navigation = useNavigation();
+  const currentYear = currentDate.getUTCFullYear();
+  const transactionList = useSelector((state: RootState) => state.transactionList);
+  const transactionListByMonth = transactionList[currentYear] ?? {};
+  const recurringTransaction = Object
+    .values(transactionListByMonth)
+    .flatMap(transaction => transaction)
+    .filter(transaction => transaction.isRecurringTransaction == 'monthly');
+
+  const sectionData = recurringTransaction
+    .reduce((acc:Array<any>, elm) => {
+      const isElementPresent = acc?.findIndex(ac => ac?.title == elm.description);
+      if (isElementPresent != -1) {
+        const item = acc[isElementPresent];
+        const newItem = {
+          ...item,
+          data: item?.data ? [...item?.data, elm]: [elm],
+        };
+        acc[isElementPresent] = newItem;
+      }else {
+        const item = {
+          title: elm.description,
+          data: [elm]
+        };
+        return acc?.concat(item);
+      }
+      return acc;
+    }, []);
+  return (
+    <>
+      <YStack justifyContent="flex-start" flex={1} padding="$4">
+
+        <SectionList
+          sections={sectionData}
+          stickySectionHeadersEnabled={false}
+          renderSectionHeader={({section: {title, data}}) => (
+            <H2>{title} - {data.length} transactions</H2>
+          )}
+          renderItem={({item}) =>(
+            <Card
+              key={item.id}
+              elevate
+              borderRadius="$6"
+              marginVertical="$2"
+              onPress={() => {
+                navigation.navigate('historyEntryDetails', {entryId: item.id});
+              }}
+            >
+              <Card.Header>
+                <XStack justifyContent="space-between">
+                  <H5>
+                    {item.description}-{new Intl.NumberFormat('en-CA', {
+                    style: 'currency',
+                    currency: 'CAD'
+                  }).format(item.amount)}
+                  </H5>
+                  <ChevronRight
+                    color={colors.text}
+                  />
+                </XStack>
+              </Card.Header>
+              <Card.Footer paddingHorizontal="$3" paddingBottom="$2">
+                <XStack
+                  style={{
+                    borderWidth: 2,
+                    borderRadius: 8,
+                    borderColor: colors.border
+                  }}>
+                  <Paragraph paddingHorizontal="$3" margin="$1">
+                    {item.categoryType}
+                  </Paragraph>
+                </XStack>
+                <XStack
+                  style={{
+                    borderWidth: 2,
+                    borderRadius: 8,
+                    borderColor: colors.border,
+                    paddingHorizontal: 8,
+                    marginHorizontal: 8
+                  }}>
+                  <Paragraph paddingHorizontal="$3" margin="$1">
+                    {item.isRecurringTransaction}
+                  </Paragraph>
+                </XStack>
+              </Card.Footer>
+            </Card>
+          )}
+        />
+      </YStack>
+    </>
+  )
+}

--- a/src/utils/frequency.ts
+++ b/src/utils/frequency.ts
@@ -1,0 +1,35 @@
+//'Never Repeat','Weekly', 'Bi-Weekly (every two weeks)', 'Monthly', 'Quarterly (every 3 months)','Semi-Annually (twice a year)', 'Annually'
+const frequencyList = [
+  {
+    id: 'neverRepeat',
+    name: 'Never Repeat',
+  },
+  // {
+  //   id: 'weekly',
+  //   name: 'Weekly',
+  // },
+  // {
+  //   id: 'biWeekly',
+  //   name: 'Bi-Weekly (every two weeks)'
+  // },
+  {
+    id: 'monthly',
+    name: 'Monthly',
+  },
+  // {
+  //   id: 'quarterly',
+  //   name: 'Quarterly (every 3 months)'
+  // },
+  // {
+  //   id: 'semiAnnually',
+  //   name: 'Semi-Annually (twice a year)'
+  // },
+  // {
+  //   id: 'annually',
+  //   name: 'Annually',
+  // }
+];
+
+export {
+  frequencyList,
+}


### PR DESCRIPTION
- Add transaction screen now has new option to select transaction frequency (defaults to never)
- Currently only supports monthly repeat
- Update schema to transactionList to tag repeating transaction
- Account and History screen has option to view recurring transaction 
![image](https://github.com/user-attachments/assets/ebea2822-b0a8-40f6-b096-60084c9a7f34)
![image](https://github.com/user-attachments/assets/39caa9f0-0ff6-4d6d-b00a-c32690ca7fba)
![image](https://github.com/user-attachments/assets/0198a768-fe7b-43e6-8c93-0a0ee6a2aa44)
